### PR TITLE
Add GenericFolder#get_items method

### DIFF
--- a/lib/model/calendar_item.rb
+++ b/lib/model/calendar_item.rb
@@ -104,8 +104,8 @@ module Viewpoint
       end
 
       # Initialize an Exchange Web Services item of type CalendarItem
-      def initialize(ews_item, shallow = true)
-        super(ews_item, shallow)
+      def initialize(ews_item, opts={})
+        super(ews_item, opts)
       end
       
       # Add attendees to this CalendarItem. This does not commit the changes so you will have to use #save! to

--- a/lib/model/contact.rb
+++ b/lib/model/contact.rb
@@ -75,8 +75,8 @@ module Viewpoint
       end
 
       # Initialize an Exchange Web Services item of type Contact
-      def initialize(ews_item, shallow = true)
-        super(ews_item, shallow)
+      def initialize(ews_item, opts={})
+        super(ews_item, opts)
       end
       
       def set_email_addresses(email1, email2=nil, email3=nil)

--- a/lib/model/event.rb
+++ b/lib/model/event.rb
@@ -42,7 +42,7 @@ module Viewpoint
         # body when the message is viewed.
         @message = nil
 
-        super(ews_item, parent_folder)
+        super(ews_item, :shallow => parent_folder)
       end
 
 

--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -329,7 +329,7 @@ module Viewpoint
         if(resp.status == 'Success')
           resp.items.map do |item|
             type = item.keys.first
-            eval "#{type.to_s.camel_case}.new(item[type], #{shallow})"
+            eval "#{type.to_s.camel_case}.new(item[type], :shallow => #{shallow})"
           end
         else
           raise EwsError, "Could not retrieve items. #{resp.code}: #{resp.message}"

--- a/lib/model/item.rb
+++ b/lib/model/item.rb
@@ -68,10 +68,10 @@ module Viewpoint
       # Initialize an Exchange Web Services item
       # @param [Hash] ews_item A hash representing this item
       # @param [Boolean] shallow Whether or not we have retrieved all the elements for this object
-      def initialize(ews_item, shallow = true)
+      def initialize(ews_item, opts={})
         super() # Calls initialize in Model (creates @ews_methods Array)
         @ews_item = ews_item
-        @shallow = shallow
+        @shallow = opts.has_key?(:shallow) ? opts[:shallow] : true
         @item_id = ews_item[:item_id][:id]
         @change_key = ews_item[:item_id][:change_key]
         @text_only = false

--- a/lib/model/meeting_message.rb
+++ b/lib/model/meeting_message.rb
@@ -22,8 +22,8 @@ module Viewpoint
   module EWS
     class MeetingMessage < Item
 
-      def initialize(ews_item, shallow = true)
-        super(ews_item, shallow)
+      def initialize(ews_item, opts={})
+        super(ews_item, opts)
       end
     end # MeetingMessage
   end # EWS

--- a/lib/model/message.rb
+++ b/lib/model/message.rb
@@ -65,8 +65,8 @@ module Viewpoint
       end
 
       # Initialize an Exchange Web Services item of type Message
-      def initialize(ews_item, shallow = true)
-        super(ews_item, shallow)
+      def initialize(ews_item, opts={})
+        super(ews_item, opts)
       end
 
       def headers

--- a/lib/model/task.rb
+++ b/lib/model/task.rb
@@ -73,8 +73,8 @@ module Viewpoint
 
 
       # Initialize an Exchange Web Services item of type Task
-      def initialize(ews_item, shallow = true)
-        super(ews_item, shallow)
+      def initialize(ews_item, opts={})
+        super(ews_item, opts)
       end
 
       # Delete this item


### PR DESCRIPTION
Here's a small patch that provides the caller with a GenericFolder#get_items method to request multiple items with a single call. There is also a change to GenericFolder#find_items to allow the caller to specify additional properties within an item shape option.

These changes are useful when you want to reduce the time it takes to find and and retrieve items with fields that are not available from the find_items call (e.g. Body & ToRecipients). For example, to find recently changed items in a date range and retrieve these items with all their properties:

```
shallow_items = CalendarFolder#items_between(
  start_time,
  end_time,
  { :item_shape => {
      :base_shape => 'IdOnly',
      :additional_properties => {
        :field_uRI => [ 'item:LastModifiedTime' ]
      }
    }
  }
)

items_ids_needed = determine_desired_items(items)

deep_items = CalendarFolder#get_items(
  item_ids_needed,
  nil,
  { :item_shape => {
      :base_shape => 'AllProperties',
      :body_type => 'Text'
    }
  }
)
```
