### PR TITLE
Raise an EwsError exception when parsing an empty response

### DIFF
--- a/lib/soap/handsoap/ews_service.rb
+++ b/lib/soap/handsoap/ews_service.rb
@@ -769,6 +769,7 @@ module Viewpoint
 
         def parse!(response, opts = {})
           return response if @@raw_soap
+          raise EwsError, "Can't parse an empty response. Please check your endpoint." if(response.nil?)
           EwsParser.new(response).parse(opts)
         end
 


### PR DESCRIPTION
Here's a one line patch to address the case where an empty response is returned. This occurs when a user provides a WebDAV instead of an EWS endpoint, where the HTTP-based authentication still succeeds.

Without the patch, the '/' method is sent to a nil object.

```
NoMethodError: undefined method `/' for nil:NilClass
    from .../gems/activesupport-3.0.5/lib/active_support   /whiny_nil.rb:48:in `method_missing'
    from .../lib/soap/handsoap/parser.rb:28:in `initialize'
from .../lib/soap/handsoap/ews_service.rb:772:in `new'
from .../lib/soap/handsoap/ews_service.rb:772:in `parse!'
from .../lib/soap/handsoap/ews_service.rb:165:in `find_folder'
from .../lib/model/generic_folder.rb:75:in `find_folders'
from .../lib/model/calendar_folder.rb:34:in `find_folders'
```

With this patch, an EwsError exception is raised instead.
