### PR TITLE
added Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'http://rubygems.org'
+
+gemspec

--- a/viewpoint.gemspec
+++ b/viewpoint.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = 'viewpoint'
   s.version = version
-  s.date		= Date.today.to_s
+  s.date    = Date.today.to_s
   s.summary = 'A Ruby client access library for Microsoft Exchange Web Services (EWS)'
   s.description = 'A Ruby client access library for Microsoft Exchange Web Services (EWS).  Examples can be found here: http://distributed-frostbite.blogspot.com'
 
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['Changelog.txt', 'README', 'COPYING.txt', 'TODO', 'lib/**/*']
   s.require_path = 'lib'
-  s.rdoc_options	= %w(-x test/ -x examples/)
+  s.rdoc_options = %w(-x test/ -x examples/)
   s.extra_rdoc_files = %w(README COPYING.txt)
 
   s.add_runtime_dependency  'handsoap'


### PR DESCRIPTION
makes it easy to install required gems. helpful for devs who clone or fork the project (ie when the dependencies aren't installed by rubygems with `gem install`). a simple `bundle install` will install dependent gems (this command requires the bundler gem).

the Gemfile uses gemspec to pull dependency info from the .gemspec file (DRY)
