### PR TITLE
MailboxUser.find_user breaks if user is also in auth'd user's contacts

### DIFF
--- a/lib/soap/handsoap/parsers/ews_parser.rb
+++ b/lib/soap/handsoap/parsers/ews_parser.rb
@@ -225,8 +225,9 @@ module Viewpoint
           resolution_set = []
           (@response/"//#{NS_EWS_MESSAGES}:ResolutionSet/*").each do |r|
             mbox_hash    = mailbox((r/"#{NS_EWS_TYPES}:Mailbox").first)
-            contact_hash = contact((r/"#{NS_EWS_TYPES}:Contact").first)
-            resolution_set << mbox_hash.merge(contact_hash)
+            contact_xml  = (r/"#{NS_EWS_TYPES}:Contact").first
+            next if !contact_xml
+            resolution_set << mbox_hash.merge(contact(contact_xml))
           end
           resolution_set
         end


### PR DESCRIPTION
In the following scenario:
- authenticated as me@mycompany.com
- me@mycompany.com has me@mycompany.com as a contact

Then if I issue:

``` ruby
include Viewpoint::EWS
EWS.endpoint = 'https://mycompany.com/ews/exchange.asmx'
EWS.set_auth('me@mycompany.com', 'password')
MailboxUser.find_user('me@mycompany.com')
```

I get a NilClass error:

```
/Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/soap/handsoap/parsers/ews_parser.rb:219:in `contact': undefined method `native_element' for nil:NilClass (NoMethodError)
        from /Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/soap/handsoap/parsers/ews_parser.rb:232:in `block in resolution_set'
        from /Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/soap/handsoap/parsers/ews_parser.rb:228:in `each'
        from /Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/soap/handsoap/parsers/ews_parser.rb:228:in `resolution_set'
        from /Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/soap/handsoap/parsers/ews_parser.rb:29:in `resolve_names_response'
        from /Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/soap/handsoap/parser.rb:44:in `call'
        from /Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/soap/handsoap/parser.rb:44:in `parse'
        from /Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/soap/handsoap/ews_service.rb:774:in `parse!'
        from /Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/soap/handsoap/ews_service.rb:119:in `resolve_names'
        from /Users/geoffwa/.rvm/gems/ruby-1.9.3-p0/gems/viewpoint-0.1.26/lib/model/mailbox_user.rb:36:in `find_user'
```

It looks like ResolveNames is also returning the auth'd users contact, which breaks EwsParser as it expects all <t:Resolution> entities to have a <t:Contact> child.

I worked  this by skipping <t:Resolution> entities with no <t:Contact>. This should work okay until we want to start searching for users who _are_ contacts.

The returned SOAP response for the case above looks something like:

``` xml
<m:ResolutionSet TotalItemsInView="2" IncludesLastItemInRange="true">
  <t:Resolution>
    <t:Mailbox>
      <t:Name>me@mycompany.com</t:Name>
      <t:EmailAddress>me@mycompany.com</t:EmailAddress>
      <t:RoutingType>SMTP</t:RoutingType>
      <t:MailboxType>Mailbox</t:MailboxType>
    </t:Mailbox>
    <t:Contact>
      <!-- yada yada -->
    </t:Contact>
  </t:Resolution>
  <t:Resolution>
    <t:Mailbox>
      <t:Name>me@mycompany.com</t:Name>
      <t:EmailAddress>me@mycompany.com</t:EmailAddress>
      <t:RoutingType>SMTP</t:RoutingType>
      <t:MailboxType>Contact</t:MailboxType>
      <t:ItemId Id="really-long-string"
        ChangeKey="not-quite-as-long-string"/>
    </t:Mailbox>
  </t:Resolution>
</m:ResolutionSet>
```
