### PR TITLE
Implemented call to ConvertId web service 

### DIFF
--- a/lib/soap/handsoap/ews_service.rb
+++ b/lib/soap/handsoap/ews_service.rb
@@ -234,12 +234,28 @@ module Viewpoint
           parse!(resp)
         end
 
-        def convert_id
+        # Converts item and folder identifiers between formats that are accepted by Microsoft Exchange
+        # @see http://msdn.microsoft.com/en-us/library/bb799665.aspx
+        #
+        # @param [String] id identifier to convert
+        # @param [String] mailbox mailbox where is located the item
+        # @param [String] alternate_id_format Format of the identifier to be converted, by default Exchange Web Services identifier
+        # @param [String] destination_format Destination format, by default Outlook identifier
+        def convert_id(id, mailbox, alternate_id_format = 'EwsId', destination_format = 'HexEntryId')
           action = "#{SOAP_ACTION_PREFIX}/ConvertId"
-          resp = invoke("#{NS_EWS_MESSAGES}:ConvertId", action) do |convert_id|
-            build_convert_id!(convert_id)
+          resp = invoke("#{NS_EWS_MESSAGES}:ConvertId", action) do |root|
+            build!(root) do
+              root.set_attr('DestinationFormat', destination_format)
+              root.add("#{NS_EWS_MESSAGES}:SourceIds") do |source_ids|
+                source_ids.add("#{NS_EWS_TYPES}:AlternateId") do |alternate_id|
+                  alternate_id.set_attr('Format', alternate_id_format)
+                  alternate_id.set_attr('Id', id)
+                  alternate_id.set_attr('Mailbox', mailbox)
+                end
+              end
+            end
           end
-          parse_convert_id(resp)
+          parse!(resp)
         end
 
         # Creates folders, calendar folders, contacts folders, tasks folders, and search folders.


### PR DESCRIPTION
The implementation is working in a production environment. We are using it to convert the exchange identifier to a outlook identifier. 

I have been trying to add some specs, but the conversion seems to depend on the connected user and the conversion algorithm is not public, so it is not clear how to test it.

An example of the different identifiers returned by the WS

```
EwsId: RgAAAACQMuGHiFSJSIloWoCvVK8GBwAz8SDgJttUQ7DmoqUdUAESAAABYTt2AADOpYf9bHwLS7mNbNTz9uutAJqONrw5AAAA
EwsLegacyId: AAAiAHBlam1hbi55YXZhcmFzaGF5ZXJpQGdydXBvYmJ2YS5jb20ARgAAAAAAkDLhh4hUiUiJaFqAr1SvBgcAM/Eg4CbbVEOw5qKlHVABEgAAAWE7dgAAzqWH/Wx8C0u5jWzU8/brrQCajja8OQAA
EntryId: AAAAAJAy4YeIVIlIiWhagK9UrwYHADPxIOAm21RDsOaipR1QARIAAAFhO3YAAM6lh/1sfAtLuY1s1PP2660Amo42vDkAAA==
HexEntryId: 000000009032E1878854894889685A80AF54AF06070033F120E026DB5443B0E6A2A51D500112000001613B760000CEA587FD6C7C0B4BB98D6CD4F3F6EBAD009A8E36BC390000
StoreId: RgAAAACQMuGHiFSJSIloWoCvVK8GBwAz8SDgJttUQ7DmoqUdUAESAAABYTt2AADOpYf9bHwLS7mNbNTz9uutAJqONrw5AAAA
```
