### PR TITLE
change hardcoded symbol reference in method to method argument

### DIFF
--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -93,7 +93,7 @@ module Viewpoint
       # @return [Array<String>] Return an Array of folder names.
       # @raise [EwsError] raised when the backend SOAP method returns an error.
       def self.folder_names(root = :msgfolderroot)
-        resp = (Viewpoint::EWS::EWS.instance).ews.find_folder([:msgfolderroot], 'Shallow')
+        resp = (Viewpoint::EWS::EWS.instance).ews.find_folder([root], 'Shallow')
         if(resp.status == 'Success')
           flds = []
           resp.items.each do |f|


### PR DESCRIPTION
My expectation, when reading the code in lib/model/generic_folder.rb

was to use it in the following way:

root = Viewpoint::EWS::Folder.get_folder('Inbox')
folder_names = Viewpoint::EWS::Folder.folder_names :root

or for public folders
folder_names = Viewpoint::EWS::Folder.folder_names :publicfoldersroot

However, the methods were not using the argument but an hardcoded symbol, surely an oversight when refactoring the code?

This is an example fix, more to follow once confirmed whether this is actually the right way or I am completely missing something here
