### PR TITLE
Fix undefined method `items'

### DIFF
--- a/lib/ews/folder_accessors.rb
+++ b/lib/ews/folder_accessors.rb
@@ -70,9 +70,15 @@ module Viewpoint::EWS::FolderAccessors
     resp = ews.find_folder opts
     if resp.success?
       folders = []
-      resp.items.each do |f|
-        folders << class_by_name(f.keys.first).new(ews, f)
+
+      if resp.respond_to?('items')
+        resp.items.each do |f|
+          folders << class_by_name(f.keys.first).new(ews, f)
+        end
+      else
+          folders = find_folders_parser(resp)
       end
+
       folders
     else
       raise EwsError, "Could not retrieve folders. #{resp.code}: #{resp.message}"


### PR DESCRIPTION
Hi,

I wrote an CLI app for new email notification (https://github.com/luxbet/outlook_notifier) using Viewpoint, but always have such error when calling e.g. find_by_name:

```
/home/fengwe/git/Viewpoint/lib/ews/folder_accessors.rb:73:in `find_by_name': undefined method `items' for #<Viewpoint::EWS::SOAP::EwsSoapResponse:0x00000001d919c0> (NoMethodError)
    from ./check.rb:67:in `block in <main>'
    from ./check.rb:67:in `collect'
    from ./check.rb:67:in `<main>'
```

Here are the request and response:

```
DEBUG  Viewpoint::EWS::SOAP::ExchangeWebService :         Sending SOAP Request:
        ----------------
<?xml version="1.0"?>
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
  <soap:Header>
    <t:RequestServerVersion Version="Exchange2010"/>
  </soap:Header>
  <soap:Body>
    <FindFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Deep">
      <FolderShape>
        <t:BaseShape>Default</t:BaseShape>
      </FolderShape>
      <m:Restriction>
        <t:IsEqualTo>
          <t:FieldURI FieldURI="folder:DisplayName"/>
          <t:FieldURIOrConstant>
            <t:Constant Value="Inbox"/>
          </t:FieldURIOrConstant>
        </t:IsEqualTo>
      </m:Restriction>
      <m:ParentFolderIds>
        <t:DistinguishedFolderId Id="msgfolderroot"/>
      </m:ParentFolderIds>
    </FindFolder>
  </soap:Body>
</soap:Envelope>

        ----------------

DEBUG  Viewpoint::EWS::SOAP::ExchangeWebService :         Received SOAP Response:
        ----------------
        <?xml version="1.0" encoding="utf-8"?>
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
  <s:Header>
    <h:ServerVersionInfo xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" MajorVersion="14" MinorVersion="2" MajorBuildNumber="318" MinorBuildNumber="2" Version="Exchange2010_SP2"/>
  </s:Header>
  <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
    <m:FindFolderResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
      <m:ResponseMessages>
        <m:FindFolderResponseMessage ResponseClass="Success">
          <m:ResponseCode>NoError</m:ResponseCode>
          <m:RootFolder TotalItemsInView="1" IncludesLastItemInRange="true">
            <t:Folders>
              <t:Folder>
                <t:FolderId Id="AAMkADJlZDVjZWRhLTA3OTUtNGE0Ni1hZTYyLTI1MzRiOTM4OTI2ZAAuAAAAAADhojqBkHOCRoSbncgJkduQAQDcCBg5gKL7T6uVjfaIKPi6AAAdHFUOAAA=" ChangeKey="AQAAABYAAAALlE7Byq/dS5uRbU0y0Q52AAAAARQj"/>
                <t:DisplayName>Inbox</t:DisplayName>
                <t:TotalCount>3454</t:TotalCount>
                <t:ChildFolderCount>0</t:ChildFolderCount>
                <t:UnreadCount>0</t:UnreadCount>
              </t:Folder>
            </t:Folders>
          </m:RootFolder>
        </m:FindFolderResponseMessage>
      </m:ResponseMessages>
    </m:FindFolderResponse>
  </s:Body>
</s:Envelope>
```

You can see there is no "items" under Folder element. Don't know if it is common or just because of our setting.

I managed to fix that in this pull request. for your reference.

Cheers,
Wei
