### PR TITLE
Let MailboxAccessors#get_user_availability accept timezone and timezone transition data

### DIFF
--- a/lib/ews/mailbox_accessors.rb
+++ b/lib/ews/mailbox_accessors.rb
@@ -49,10 +49,15 @@ module Viewpoint::EWS::MailboxAccessors
   # @option opts [DateTime] :end_time
   # @option opts [Symbol] :requested_view :merged_only/:free_busy/
   #   :free_busy_merged/:detailed/:detailed_merged
+  # @option opts [Hash] :time_zone The TimeZone data
+  #   Example: {:bias => 'UTC offset in minutes',
+  #   :standard_time => {:bias => 480, :time => '02:00:00',
+  #     :day_order => 5, :month => 10, :day_of_week => 'Sunday'},
+  #   :daylight_time => {same options as :standard_time}}
   def get_user_availability(emails, opts)
     opts = opts.clone
     args = get_user_availability_args(emails, opts)
-    resp = ews.get_user_availability(args)
+    resp = ews.get_user_availability(args.merge(opts))
     get_user_availability_parser(resp)
   end
 

--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -399,21 +399,40 @@ module Viewpoint::EWS::SOAP
     end
 
     def time_zone!(zone)
+      zone ||= {}
+      zone = {
+        bias: zone[:bias] || 480,
+        standard_time: {
+          bias: 0,
+          time: "02:00:00",
+          day_order: 5,
+          month: 10,
+          day_of_week: 'Sunday'
+        }.merge(zone[:standard_time] || {}),
+        daylight_time: {
+          bias: -60,
+          time: "02:00:00",
+          day_order: 1,
+          month: 4,
+          day_of_week: 'Sunday'
+        }.merge(zone[:daylight_time] || {})
+      }
+
       nbuild[NS_EWS_TYPES].TimeZone {
-        nbuild[NS_EWS_TYPES].Bias(480)
+        nbuild[NS_EWS_TYPES].Bias(zone[:bias])
         nbuild[NS_EWS_TYPES].StandardTime {
-          nbuild[NS_EWS_TYPES].Bias(0)
-          nbuild[NS_EWS_TYPES].Time("02:00:00")
-          nbuild[NS_EWS_TYPES].DayOrder(5)
-          nbuild[NS_EWS_TYPES].Month(10)
-          nbuild[NS_EWS_TYPES].DayOfWeek('Sunday')
+          nbuild[NS_EWS_TYPES].Bias(zone[:standard_time][:bias])
+          nbuild[NS_EWS_TYPES].Time(zone[:standard_time][:time])
+          nbuild[NS_EWS_TYPES].DayOrder(zone[:standard_time][:day_order])
+          nbuild[NS_EWS_TYPES].Month(zone[:standard_time][:month])
+          nbuild[NS_EWS_TYPES].DayOfWeek(zone[:standard_time][:day_of_week])
         }
         nbuild[NS_EWS_TYPES].DaylightTime {
-          nbuild[NS_EWS_TYPES].Bias(-60)
-          nbuild[NS_EWS_TYPES].Time("02:00:00")
-          nbuild[NS_EWS_TYPES].DayOrder(1)
-          nbuild[NS_EWS_TYPES].Month(4)
-          nbuild[NS_EWS_TYPES].DayOfWeek('Sunday')
+          nbuild[NS_EWS_TYPES].Bias(zone[:daylight_time][:bias])
+          nbuild[NS_EWS_TYPES].Time(zone[:daylight_time][:time])
+          nbuild[NS_EWS_TYPES].DayOrder(zone[:daylight_time][:day_order])
+          nbuild[NS_EWS_TYPES].Month(zone[:daylight_time][:month])
+          nbuild[NS_EWS_TYPES].DayOfWeek(zone[:daylight_time][:day_of_week])
         }
       }
     end

--- a/spec/unit/mailbox_accessors_spec.rb
+++ b/spec/unit/mailbox_accessors_spec.rb
@@ -1,0 +1,57 @@
+require_relative '../spec_helper'
+
+describe Viewpoint::EWS::MailboxAccessors do
+  let(:ecli) { Viewpoint::EWSClient.new('dontcare', 'dontcare', 'dontcare') }
+  let(:recipients) { ['anyrecipient'] }
+  let(:timezone_request) do
+"<t:TimeZone>
+  <t:Bias>0</t:Bias>
+  <t:StandardTime>
+    <t:Bias>0</t:Bias>
+    <t:Time>02:00:00</t:Time>
+    <t:DayOrder>5</t:DayOrder>
+    <t:Month>10</t:Month>
+    <t:DayOfWeek>Sunday</t:DayOfWeek>
+  </t:StandardTime>
+  <t:DaylightTime>
+    <t:Bias>0</t:Bias>
+    <t:Time>02:00:00</t:Time>
+    <t:DayOrder>1</t:DayOrder>
+    <t:Month>4</t:Month>
+    <t:DayOfWeek>Sunday</t:DayOfWeek>
+  </t:DaylightTime>
+</t:TimeZone>"
+  end
+
+  let(:default_parameters) do
+    {
+      :start_time => (Time.now - 1).iso8601,
+      :end_time => Time.now.iso8601,
+      :requested_view => :detailed
+    }
+  end
+
+  context "#get_user_availability" do
+
+    it "should care about timezones" do
+      Viewpoint::EWS::SOAP::ExchangeWebService.any_instance.
+        should_receive(:do_soap_request) do |request_document|
+          request_document.at_xpath('//soap:Envelope/soap:Body//t:TimeZone').to_s.should eq timezone_request
+        end.
+        and_return(stub(:resp, :status => 'Success'))
+
+      ecli.get_user_availability(
+        recipients,
+        default_parameters.merge(
+          :time_zone => {
+            :bias => 0,
+            :standard_time => {:bias => 0},
+            :daylight_time => {:bias => 0}
+          }
+        )
+      )
+    end
+
+  end
+
+end


### PR DESCRIPTION
Without this change the timezone will always be UTC+8 (see the [EWS example](http://msdn.microsoft.com/en-us/library/aa563445.aspx)).
