### PR TITLE
Handle empty ranges for get_user_availability

### DIFF
--- a/lib/ews/soap/ews_soap_free_busy_response.rb
+++ b/lib/ews/soap/ews_soap_free_busy_response.rb
@@ -47,7 +47,7 @@ module Viewpoint::EWS::SOAP
 
     def calendar_event_array
       result = find_in_hash_list(get_user_availability_response[1][:free_busy_view][:elems], :calendar_event_array)
-      result ? result[:elems] : nil
+      result ? result[:elems] : []
     end
 
     def working_hours

--- a/spec/unit/ews_soap_free_busy_response_spec.rb
+++ b/spec/unit/ews_soap_free_busy_response_spec.rb
@@ -86,8 +86,8 @@ EOS
       resp.status.should eq "Success"
     end
 
-    it "the calendar_event_array should be nil" do
-      resp.calendar_event_array.should be_nil
+    it "the calendar_event_array should be an empty list" do
+      resp.calendar_event_array.should eq []
     end
   end
 


### PR DESCRIPTION
When requesting a users availability with [EWSClient#get_user_availability](https://github.com/zenchild/Viewpoint/blob/57f4e02e622aaba1e475d567c0f237262e033239/lib/ews/mailbox_accessors.rb#L52) and the user is not busy during the requested time window, the current code fails with `NoMethodError: undefined method '[]' for nil:NilClass` when calling `calendar_event_array`.

The attached code will return an empty array in that case. I also wrote test cases for empty and not-empty responses.

**Please note**: This pull requests probability conflicts with https://github.com/zenchild/Viewpoint/pull/74. I'll resolve the merge conflicts in this pull request, once #74 is applied (or vice versa).
