### PR TITLE
Corrected type: changed method iso8061 to iso8601 in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ items = inbox.items
 inbox.todays_items
 
 # since a specific date
-sd = Date.iso8061 '2013-01-01'
+sd = Date.iso8601 '2013-01-01'
 inbox.items_since sd
 
 # between 2 dates
-sd = Date.iso8061 '2013-01-01'
-ed = Date.iso8061 '2013-02-01'
+sd = Date.iso8601 '2013-01-01'
+ed = Date.iso8601 '2013-02-01'
 inbox.items_between sd, ed
 ```
 ### Free/Busy Calendar Accessors


### PR DESCRIPTION
This corrects a typo in the example code within the README.md file.  The Date method iso8601 was incorrectly listed as iso8061
