### PR TITLE
Feature: TimeZoneContext and GetServerTimeZones

### DIFF
--- a/lib/ews/ews_client.rb
+++ b/lib/ews/ews_client.rb
@@ -58,6 +58,13 @@ class Viewpoint::EWSClient
     set_auto_deepen deepen
   end
 
+  # Specify a default time zone context for all time attributes
+  # @param id [String] Identifier of a Microsoft well known time zone (e.g: 'UTC', 'W. Europe Standard Time')
+  # @note A list of time zones known by the server can be requested via {EWS::SOAP::ExchangeTimeZones#get_time_zones}
+  def set_time_zone(microsoft_time_zone_id)
+    @ews.set_time_zone_context microsoft_time_zone_id
+  end
+
   private
 
 

--- a/lib/ews/soap/exchange_time_zones.rb
+++ b/lib/ews/soap/exchange_time_zones.rb
@@ -1,0 +1,56 @@
+module Viewpoint::EWS::SOAP
+
+  module ExchangeTimeZones
+    include Viewpoint::EWS::SOAP
+
+    # Request list of server known time zones
+    # @param full [Boolean] Request full time zone definition? Returns only name and id if false.
+    # @param ids [Array] Returns only the specified time zones instead of all if present
+    # @return [Array] Array of Objects responding to #id() and #name()
+    # @example Retrieving server zime zones
+    #   ews_client = Viewpoint::EWSClient.new # ...
+    #   zones = ews_client.ews.get_time_zones
+    # @todo Implement TimeZoneDefinition with sub elements Periods, TransitionsGroups and Transitions
+    def get_time_zones(full = false, ids = nil)
+      req = build_soap! do |type, builder|
+        unless type == :header
+          builder.get_server_time_zones!(full: full, ids: ids)
+        end
+      end
+      result = do_soap_request req, response_class: EwsSoapResponse
+
+      if result.success?
+        zones = []
+        result.response_messages.each do |message|
+          elements = message[:get_server_time_zones_response_message][:elems][:time_zone_definitions][:elems]
+          elements.each do |definition|
+            data = {
+                id: definition[:time_zone_definition][:attribs][:id],
+                name: definition[:time_zone_definition][:attribs][:name]
+            }
+            zones << OpenStruct.new(data)
+          end
+        end
+        zones
+      else
+        raise EwsError, "Could not get time zones"
+      end
+    end
+
+    # Sets the time zone context header
+    # @param id [String] Identifier of a Microsoft well known time zone
+    # @example Set time zone context for connection
+    #   ews_client = Viewpoint::EWSClient.new # ...
+    #   ews_client.set_time_zone 'AUS Central Standard Time'
+    #   # subsequent request will send the TimeZoneContext header
+    # @see EWSClient#set_time_zone
+    def set_time_zone_context(id)
+      if id
+        @time_zone_context = {id: id}
+      else
+        @time_zone_context = nil
+      end
+    end
+
+  end
+end

--- a/lib/ews/soap/exchange_web_service.rb
+++ b/lib/ews/soap/exchange_web_service.rb
@@ -25,6 +25,7 @@ module Viewpoint::EWS::SOAP
     include ExchangeAvailability
     include ExchangeUserConfiguration
     include ExchangeSynchronization
+    include ExchangeTimeZones
 
     attr_accessor :server_version, :auto_deepen, :no_auto_deepen_behavior, :connection, :impersonation_type, :impersonation_address
 
@@ -226,6 +227,7 @@ module Viewpoint::EWS::SOAP
     # Build the common elements in the SOAP message and yield to any custom elements.
     def build_soap!(&block)
       opts = { :server_version => server_version, :impersonation_type => impersonation_type, :impersonation_mail => impersonation_address }
+      opts[:time_zone_context] = @time_zone_context if @time_zone_context
       EwsBuilder.new.build!(opts, &block)
     end
 

--- a/lib/viewpoint.rb
+++ b/lib/viewpoint.rb
@@ -58,6 +58,7 @@ require 'ews/soap/exchange_notification'
 require 'ews/soap/exchange_synchronization'
 require 'ews/soap/exchange_availability'
 require 'ews/soap/exchange_user_configuration'
+require 'ews/soap/exchange_time_zones'
 require 'ews/soap/exchange_web_service'
 
 require 'ews/connection_helper'

--- a/spec/unit/soap/builders/ews_builder_spec.rb
+++ b/spec/unit/soap/builders/ews_builder_spec.rb
@@ -31,4 +31,9 @@ describe Viewpoint::EWS::SOAP::EwsBuilder do
     expect {@builder.send(:format_time, 'asdf')}.to raise_error(Viewpoint::EWS::EwsBadArgumentError)
   end
 
+  it 'should contain time zone context' do
+    doc = @builder.build!(time_zone_context: {id: 'SpaceTime'})
+    selector = "//soap:Header/t:TimeZoneContext/t:TimeZoneDefinition[@Id='SpaceTime']"
+    doc.root.xpath(selector, @namespaces).should be_any
+  end
 end


### PR DESCRIPTION
I implemented the TimeZoneContext Header for use in EWSClient. TimeZones can also be specified for start and end time separately (when creating or updating items). Exchange understands all 'well known' time zones. Which luckily can be retrieved from Exchange using `ExchangeWebService#get_time_zones`.

I did not implement the elements to override the logic of a time zone (Periods, TransitionsGroups and Transitions).
