### PR TITLE
Separate the logging configuration from the setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Gemfile.lock
 /test*.rb
 /\.test*
 .idea
+tmp
+vendor

--- a/lib/viewpoint.rb
+++ b/lib/viewpoint.rb
@@ -26,18 +26,8 @@ require 'logging'
 # Class Extensions (Monkey patches)
 require 'extensions/string'
 
-module Viewpoint
-  module EWS
-    attr_reader :logger
-    Logging.logger.root.level = :debug
-    Logging.logger.root.appenders = Logging.appenders.stdout
-
-    def self.root_logger
-      Logging.logger.root
-    end
-
-  end # EWS
-end
+# Load the logging setup
+require 'viewpoint/logging'
 
 # Load the Exception classes
 require 'ews/exceptions/exceptions'

--- a/lib/viewpoint/logging.rb
+++ b/lib/viewpoint/logging.rb
@@ -1,0 +1,27 @@
+=begin
+  This file is part of Viewpoint; the Ruby library for Microsoft Exchange Web Services.
+
+  Copyright © 2011 Dan Wanek <dan.wanek@gmail.com>
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+=end
+
+module Viewpoint
+  module EWS
+    attr_reader :logger
+
+    def self.root_logger
+      Logging.logger.root
+    end
+  end # EWS
+end

--- a/lib/viewpoint/logging/config.rb
+++ b/lib/viewpoint/logging/config.rb
@@ -1,0 +1,24 @@
+=begin
+  This file is part of Viewpoint; the Ruby library for Microsoft Exchange Web Services.
+
+  Copyright © 2011 Dan Wanek <dan.wanek@gmail.com>
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+=end
+
+module Viewpoint
+  module EWS
+    Logging.logger.root.level = :debug
+    Logging.logger.root.appenders = Logging.appenders.stdout
+  end # EWS
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $: << File.dirname(__FILE__) + '/../lib/'
 require 'viewpoint'
+require 'viewpoint/logging/config'
 require 'ostruct'
 require 'turn/autorun'
 require_relative 'xml_matcher'


### PR DESCRIPTION
The configuration can still be loaded in its previous form by requiring 'viewpoint/logging/config'.

There are two failing specs but these are broken on master too and look like a formatting difference rather than a "true" bug.

Resolves #121
