### PR TITLE
Ability to pass options when deleting an item

### DIFF
--- a/lib/ews/types/item.rb
+++ b/lib/ews/types/item.rb
@@ -94,11 +94,12 @@ module Viewpoint::EWS::Types
       @body_type = body_type
     end
 
-    def delete!(deltype = :hard)
+    def delete!(deltype = :hard, opts = {})
       opts = {
         :delete_type => delete_type(deltype),
         :item_ids => [{:item_id => {:id => id}}]
-      }
+      }.merge(opts)
+
       resp = @ews.delete_item(opts)
       rmsg = resp.response_messages[0]
       unless rmsg.success?


### PR DESCRIPTION
Additional options such as `:send_meeting_cancellations` were [already supported in the core](https://github.com/WinRb/Viewpoint/blob/e77191d7cb1205768180f93fa88fbfbb9b599a6b/lib/ews/soap/exchange_data_services.rb#L234-235) but there was no mechanism for passing them to [Item#delete!](https://github.com/WinRb/Viewpoint/blob/e77191d7cb1205768180f93fa88fbfbb9b599a6b/lib/ews/types/item.rb#L97).
