### PR TITLE
Alias *field_uRI as *field_uri

### DIFF
--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -624,12 +624,16 @@ module Viewpoint::EWS::SOAP
       nbuild[NS_EWS_TYPES].FieldURI('FieldURI' => expr[:field_uRI])
     end
 
+    alias_method :field_uri, :field_uRI
+
     def indexed_field_uRI(expr)
       nbuild[NS_EWS_TYPES].IndexedFieldURI(
         'FieldURI'    => expr[:field_uRI],
         'FieldIndex'  => expr[:field_index]
       )
     end
+
+    alias_method :indexed_field_uri, :indexed_field_uRI
 
     def extended_field_uRI(expr)
       nbuild[NS_EWS_TYPES].ExtendedFieldURI {
@@ -641,6 +645,8 @@ module Viewpoint::EWS::SOAP
         nbuild.parent['PropertyType'] = expr[:property_type] if expr[:property_type]
       }
     end
+
+    alias_method :extended_field_uri, :extended_field_uRI
 
     def extended_properties!(eprops)
       eprops.each {|ep| extended_property!(ep)}
@@ -672,6 +678,8 @@ module Viewpoint::EWS::SOAP
         self.send(type, expr[type])
       }
     end
+
+    alias_method :field_uri_or_constant, :field_uRI_or_constant
 
     def constant(expr)
       nbuild[NS_EWS_TYPES].Constant('Value' => expr[:value])


### PR DESCRIPTION
When performing restrictions on a find you were required to specify the field URI keys with a capitalized "RI" which looked a bit odd and was easy to forget to do (extract taken from GenericFolder):

``` ruby
{:is_greater_than_or_equal_to =>
  [{:field_uRI => {:field_uRI=>'item:DateTimeReceived'}},
    {:field_uRI_or_constant =>{:constant => {:value=>date_time.to_datetime}}}]
}}
```

This commit aliases the methods with lowercase equivalents so that the
above can be specified like this with no other changes:

``` ruby
{:is_greater_than_or_equal_to =>
  [{:field_uri => {:field_uri=>'item:DateTimeReceived'}},
    {:field_uri_or_constant =>{:constant => {:value=>date_time.to_datetime}}}]
}}
```
