### PR TITLE
Introduced response error hierarchy

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -91,16 +91,18 @@ class Viewpoint::EWS::Connection
       resp.body
     when 302
       # @todo redirect
-      raise "Unhandled HTTP Redirect"
+      raise Errors::UnhandledResponseError.new("Unhandled HTTP Redirect", resp)
+    when 401
+      raise Errors::UnauthorizedResponseError.new("Unauthorized request", resp)
     when 500
       if resp.headers['Content-Type'].include?('xml')
         err_string, err_code = parse_soap_error(resp.body)
-        raise "SOAP Error: Message: #{err_string}  Code: #{err_code}"
+        raise Errors::SoapResponseError.new("SOAP Error: Message: #{err_string}  Code: #{err_code}", resp, err_code, err_string)
       else
-        raise "Internal Server Error. Message: #{resp.body}"
+        raise Errors::ServerError.new("Internal Server Error. Message: #{resp.body}", resp)
       end
     else
-      raise "HTTP Error Code: #{resp.status}, Msg: #{resp.body}"
+      raise Errors::ResponseError.new("HTTP Error Code: #{resp.status}, Msg: #{resp.body}", resp)
     end
   end
 

--- a/lib/ews/errors.rb
+++ b/lib/ews/errors.rb
@@ -1,0 +1,56 @@
+=begin
+  This file is part of Viewpoint; the Ruby library for Microsoft Exchange Web Services.
+
+  Copyright © 2011 Dan Wanek <dan.wanek@gmail.com>
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+=end
+
+module Viewpoint::EWS::Errors
+  class ResponseError < RuntimeError
+    attr_reader :response
+
+    def initialize(message, response)
+      super(message)
+      @response = response
+    end
+
+    def status
+      response.status
+    end
+
+    def body
+      response.body
+    end
+  end
+
+  class UnhandledResponseError < ResponseError
+  end
+
+  class ServerError < ResponseError
+  end
+
+  class UnauthorizedResponseError < ResponseError
+  end
+
+  class SoapResponseError < ResponseError
+    attr_reader :faultcode,
+                :faultstring
+
+    def initialize(message, response, faultcode, faultstring)
+      super(message, response)
+      @faultcode = faultcode
+      @faultstring = faultstring
+    end
+  end
+end

--- a/lib/viewpoint.rb
+++ b/lib/viewpoint.rb
@@ -63,6 +63,7 @@ require 'ews/soap/exchange_user_configuration'
 require 'ews/soap/exchange_time_zones'
 require 'ews/soap/exchange_web_service'
 
+require 'ews/errors'
 require 'ews/connection_helper'
 require 'ews/connection'
 


### PR DESCRIPTION
In order to be able to distinguish between types of error more easily, an error type hierarchy was introduced. The response itself is embedded within the errors with helpers for accessing the status and body more easily.

This also introduces a special case for 401 Unauthorized. 401 should be the only breaking change as this is the only status that had its message altered.
