### PR TITLE
Add ability to override HTTPClient#receive_timeout

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -26,6 +26,8 @@ class Viewpoint::EWS::Connection
   #   @example https://<site>/ews/Exchange.asmx
   # @param [Hash] opts Misc config options (mostly for developement)
   # @option opts [Fixnum] :ssl_verify_mode
+  # @option opts [Fixnum] :receive_timeout override the default receive timeout
+  #   seconds
   # @option opts [Array]  :trust_ca an array of hashed dir paths or a file
   def initialize(endpoint, opts = {})
     @log = Logging.logger[self.class.name.to_s.to_sym]
@@ -39,6 +41,7 @@ class Viewpoint::EWS::Connection
     @httpcli.ssl_config.verify_mode = opts[:ssl_verify_mode] if opts[:ssl_verify_mode]
     # Up the keep-alive so we don't have to do the NTLM dance as often.
     @httpcli.keep_alive_timeout = 60
+    @httpcli.receive_timeout = opts[:receive_timeout] if opts[:receive_timeout]
     @endpoint = endpoint
   end
 


### PR DESCRIPTION
We've experienced some servers responding slowly and wanted to extend the receive timeout to see if that helped.

Thought it was worth opening a PR so other people have the same ability.
