### PR TITLE
Added ability to set SSL version

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -37,6 +37,7 @@ class Viewpoint::EWS::Connection
       end
     end
     @httpcli.ssl_config.verify_mode = opts[:ssl_verify_mode] if opts[:ssl_verify_mode]
+    @httpcli.ssl_config.ssl_version = opts[:ssl_version] if opts[:ssl_version]
     # Up the keep-alive so we don't have to do the NTLM dance as often.
     @httpcli.keep_alive_timeout = 60
     @endpoint = endpoint


### PR DESCRIPTION
We had a client whose server would only work with SSLv2 and so we needed to relax the default SSL version requirement in our version of the httpclient gem.
