### PR TITLE
Get events for multiple users in a single request

### DIFF
--- a/lib/ews/soap/ews_soap_free_busy_response.rb
+++ b/lib/ews/soap/ews_soap_free_busy_response.rb
@@ -37,10 +37,30 @@ module Viewpoint::EWS::SOAP
       envelope[1][:body][:elems]
     end
 
+    # def get_user_availability_response
+    #   body.first[:get_user_availability_response][:elems].first[:free_busy_response_array][:elems].first[:free_busy_response][:elems]
+    # end
+
     def get_user_availability_response
-      body.first[:get_user_availability_response][:elems].first[:free_busy_response_array][:elems].first[:free_busy_response][:elems]
+      # This method handles multiple calender when an array of mulitple users is passed through cli.get_user_availability
+      events = []
+      body.first[:get_user_availability_response][:elems].first[:free_busy_response_array][:elems].each_with_index do |e, i|
+        e[:free_busy_response][:elems][1][:free_busy_view][:elems][1][:calendar_event_array][:elems].each do |c| 
+      
+          if c[:calendar_event][:elems].select { |element| element.is_a?(Hash) && element.has_key?(:user_position)}.length == 0
+            c[:calendar_event][:elems] << { :user_position => i }  
+          end
+          events << c
+        end
+      end
+
+      result = body.first[:get_user_availability_response][:elems].first[:free_busy_response_array][:elems].first[:free_busy_response][:elems]
+      result[1][:free_busy_view][:elems][1][:calendar_event_array][:elems] = events
+      
+      result
     end
 
+    
     def response
       body
     end


### PR DESCRIPTION
Hi, 

Thanks for this very useful gem. 

There is a little issue regarding user availability. The `get_user_availability` method takes as parameter an array of email addresses. That's needed when one wants to get availabilities of multiple users through a single request to the Exchange server. But from my understanding, this method only returns availability for the first user in the array.

This commit proposes a way to return availability for all users specified within the array. Regarding the result, since Exchange do no insert any user id within its response, availabilities are returned with a `user` value that contains the index of the user in the array passed as parameter.

It might probably be more efficient to parse directly the XML response from Exchange with Nokigiri (missing time to do so). 

Thanks again for the library. 
Fabrice. 
