### PR TITLE
Changed PARAMETERS constant to be an array of symbols, instead of an array of strings converted into symbols.

### DIFF
--- a/lib/ews/templates/calendar_item.rb
+++ b/lib/ews/templates/calendar_item.rb
@@ -5,7 +5,7 @@ module Viewpoint::EWS
   class CalendarItem < OpenStruct
 
       # Available parameters with the required ordering
-      PARAMETERS = %w{mime_content item_id parent_folder_id item_class subject sensitivity body attachments
+      PARAMETERS = %i{mime_content item_id parent_folder_id item_class subject sensitivity body attachments
         date_time_received size categories in_reply_to is_submitted is_draft is_from_me is_resend is_unmodified
         internet_message_headers date_time_sent date_time_created response_objects reminder_due_by reminder_is_set
         reminder_minutes_before_start display_cc display_to has_attachments extended_property culture start end
@@ -17,7 +17,7 @@ module Viewpoint::EWS
         meeting_time_zone start_time_zone end_time_zone conference_type allow_new_time_proposal is_online_meeting
         meeting_workspace_url net_show_url effective_rights last_modified_name last_modified_time is_associated
         web_client_read_form_query_string web_client_edit_form_query_string conversation_id unique_body
-      }.map(&:to_sym).freeze
+      }.freeze
 
       # Returns a new CalendarItem template
       def initialize(opts = {})


### PR DESCRIPTION
``` ruby
# In irb:
2.1.5 :001 > %i{ hello world }
 => [:hello, :world]
```

The `%i` prefix tells ruby that anything after `{` or `[` will be an array of symbols. 

I've simply removed changed the CONSTANTS parameter list from being an array of strings mapped into symbols to simply an array of symbols.
