### PR TITLE
Add recurring event support when creating events.

### DIFF
--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -830,9 +830,62 @@ module Viewpoint::EWS::SOAP
       }
     end
 
+    def calendar_item_type!(type)
+      nbuild[NS_EWS_TYPES].CalendarItemType(type)
+    end
+
+    def recurrence!(item)
+      nbuild[NS_EWS_TYPES].Recurrence {
+        item.each_pair { |k, v|
+          self.send("#{k}!", v)
+        }
+      }
+    end
+
+    def daily_recurrence!(item)
+      nbuild[NS_EWS_TYPES].DailyRecurrence {
+        item.each_pair { |k, v|
+          self.send("#{k}!", v)
+        }
+      }
+    end
+
+    def weekly_recurrence!(item)
+      nbuild[NS_EWS_TYPES].WeeklyRecurrence {
+        item.each_pair { |k, v|
+          self.send("#{k}!", v)
+        }
+      }
+    end
+
+    def interval!(num)
+      nbuild[NS_EWS_TYPES].Interval(num)
+    end
+
+    def no_end_recurrence!(item)
+      nbuild[NS_EWS_TYPES].NoEndRecurrence {
+        item.each_pair { |k, v|
+          self.send("#{k}!", v)
+        }
+      }
+    end
+
+    def numbered_recurrence!(item)
+      nbuild[NS_EWS_TYPES].NumberedRecurrence {
+        item.each_pair { |k, v|
+          self.send("#{k}!", v)
+        }
+      }
+    end
+
+    def number_of_occurrences!(count)
+      nbuild[NS_EWS_TYPES].NumberOfOccurrences(count)
+    end
+
+
     def task!(item)
       nbuild[NS_EWS_TYPES].Task {
-        item.each_pair {|k,v|
+        item.each_pair {|k, v|
           self.send("#{k}!", v)
         }
       }
@@ -949,7 +1002,7 @@ module Viewpoint::EWS::SOAP
     end
 
     def start_date!(sd)
-      nbuild[NS_EWS_TYPES].StartDate format_time(sd[:text])
+      nbuild[NS_EWS_TYPES].StartDate sd[:text]
     end
 
     def due_date!(dd)


### PR DESCRIPTION
Adds support for creating recurring events; fixes #152. Though `recurring?` and `recurrence` fields are defined on [calendar_item](https://github.com/WinRb/Viewpoint/blob/master/lib/ews/types/calendar_item.rb#L9), the necessary handlers in ews_builder don't exist to actually create the required SOAP fields. This PR adds that.

It seems that the gem's architecture requires explicitly whitelisting any SOAP fields that are going to be created. Given that, this PR doesn't cover all the [possible ways](http://msdn.microsoft.com/en-us/library/aa580471(v=exchg.150).aspx) to create a recurring event, but it does cover the common ones (daily_recurrence and weekly_recurrence). I can add coverage for the rest of the options, but would like to get feedback from the maintainers on this first cut before doing so.

With this PR, the code for creating a recurring event would look like: 

```
calendar = @cli.get_folder(:calendar)
attrs = {
  :subject => "my-recurring-event",
  :start => Time.now,
  :end => Time.now + (60 * 60),
  :recurrence => { :daily_recurrence => { :interval => 1},
                   :numbered_recurrence => { 
                     :start_date => { :text => Time.now.strftime("%Y-%m-%d") },
                     :number_of_occurrences => 3
                   }
                 }
}

event = calendar.create_item(attrs)
```

The tests pass after adding this, but I'm not sure how good the coverage is and also am only using a small subset of the gem's surface area, so let me know if this raises any issues. Thanks!