### PR TITLE
Fixed get_item and get_items to accept :occurrence_item_id

### DIFF
--- a/lib/ews/item_accessors.rb
+++ b/lib/ews/item_accessors.rb
@@ -115,9 +115,20 @@ private
     }
     default_args[:item_ids] = case item_id
     when Hash
-      [{:item_id => item_id}]
+      if item_id.keys.index(:id)
+        [{:item_id => item_id}]
+      else
+        [item_id]
+      end
     when Array
-      item_id.map{|i| {:item_id => {:id => i}}}
+      item_id.map do |i|
+        case i
+        when Hash
+          i
+        else
+          {:item_id => {:id => i}}
+        end
+      end
     else
       [{:item_id => {:id => item_id}}]
     end

--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -1182,10 +1182,9 @@ module Viewpoint::EWS::SOAP
       when :item_id
         item_id!(item)
       when :occurrence_item_id
-        occurrence_item_id!(
-          item[:recurring_master_id], item[:change_key], item[:instance_index])
+        occurrence_item_id!(item)
       when :recurring_master_item_id
-        recurring_master_item_id!(item[:occurrence_id], item[:change_key])
+        recurring_master_item_id!(item)
       else
         raise EwsBadArgumentError, "Bad ItemId type. #{type}"
       end

--- a/spec/unit/item_accessors_spec.rb
+++ b/spec/unit/item_accessors_spec.rb
@@ -31,4 +31,41 @@ describe Viewpoint::EWS::ItemAccessors do
     end
   end
 
+  context "get_item_args should handle :occurrence_item_id" do
+    class GetItemArgsAccessor
+      include Viewpoint::EWS::ItemAccessors
+      def call_get_item_args(*args)
+        get_item_args(*args)
+      end
+    end
+
+    it "should handle an :occurrence_item_id hash" do
+      occurrence_item_id = {:occurrence_item_id => {:recurring_master_id => 'rid1', :change_key => 'ck', :instance_index => 1}}
+      result = GetItemArgsAccessor.new.call_get_item_args(occurrence_item_id, {})
+      result[:item_ids].should eq [occurrence_item_id]
+    end
+
+    it "should handle an Array of :occurrence_item_id hashes" do
+      occurrences =  [
+          {:occurrence_item_id => {:recurring_master_id => 'rid1', :change_key => 'ck1', :instance_index => 1}},
+          {:occurrence_item_id => {:recurring_master_id => 'rid2', :change_key => 'ck2', :instance_index => 2}},
+          {:occurrence_item_id => {:recurring_master_id => 'rid3', :change_key => 'ck3', :instance_index => 3}},
+      ]
+      result = GetItemArgsAccessor.new.call_get_item_args(occurrences, {})
+      result[:item_ids].should eq occurrences
+    end
+
+    it "should handle an :id hash" do
+      id = {:id => 'id1', :change_key => 'ck1'}
+      result = GetItemArgsAccessor.new.call_get_item_args(id, {})
+      result[:item_ids].should eq [{:item_id => {:id => 'id1', :change_key => 'ck1'}}]
+    end
+
+    it "should handle an Array of id strings" do
+      ids = ['id1', 'id2', 'id3']
+      result = GetItemArgsAccessor.new.call_get_item_args(ids, {})
+      result[:item_ids].should eq [{:item_id=>{:id => 'id1'}},{:item_id=>{:id => 'id2'}},{:item_id=>{:id => 'id3'}}]
+    end
+  end
+
 end


### PR DESCRIPTION
Fixed ItemAccessors#get_item_args to support :occurrence_item_id (spec updated)

Fixed EwsBuilder#dispatch_item_id! calls to occurrence_item_id! and recurring_master_item_id! which had the wrong number of arguments.

This issue was seen attempting to call get_items to expand a recurring appointment by using :occurrence_item_id as parameter for the item_id (ItemAccessors#get_item and #get_items).

After fixing #get_item_args, found EwsBuilder#dispatch_item_id! was coded to use the :occurrence_item_id and :recurring_master_item_id, but the call used the wrong number of arguments to the sub-routine.

Calling get_item( {:occurrence_item_id=>{:recurring_master_id => 'rid1', :instance_index => 1 }}, opts ) will now work!
