### PR TITLE
Full calendar item update support

### DIFF
--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -24,9 +24,30 @@ module Viewpoint::EWS::SOAP
     include Viewpoint::EWS
     include Viewpoint::StringUtils
 
+    RESERVED_ATTRIBUTE_KEYS = %i{text sub_elements xmlns_attribute}.freeze
+
     attr_reader :nbuild
     def initialize
       @nbuild = Nokogiri::XML::Builder.new
+    end
+
+    def self.camel_case_attributes(input)
+      case input
+      when Hash
+        result = {}
+        input.each do |attrib_key, attrib_value|
+          unless RESERVED_ATTRIBUTE_KEYS.include?(attrib_key)
+            attrib_key = camel_case(attrib_key)
+          end
+
+          result[attrib_key] = camel_case_attributes(attrib_value)
+        end
+        result
+      when Array
+        result = input.map { |value| camel_case_attributes(value) }
+      else
+        input
+      end
     end
 
     # Build the SOAP envelope and yield this object so subelements can be built. Once

--- a/lib/ews/types/calendar_item.rb
+++ b/lib/ews/types/calendar_item.rb
@@ -69,15 +69,11 @@ module Viewpoint::EWS::Types
 
           # Remap attributes because ews_builder #dispatch_field_item! uses #build_xml!
           item_attributes = item.to_ews_item.map do |name, value|
-            if value.is_a? String
+            case value
+            when String
               {name => {text: value}}
-            elsif value.is_a? Hash
-              node = {name => {}}
-              value.each do |attrib_key, attrib_value|
-                attrib_key = camel_case(attrib_key) unless attrib_key == :text
-                node[name][attrib_key] = attrib_value
-              end
-              node
+            when Hash
+              {name => Viewpoint::EWS::SOAP::EwsBuilder.camel_case_attributes(value)}
             else
               {name => value}
             end
@@ -102,16 +98,13 @@ module Viewpoint::EWS::Types
           raise EwsCreateItemError, "Could not update calendar item. #{rm.code}: #{rm.message_text}" unless rm
         end
       end
-
     end
 
     def duration_in_seconds
       iso8601_duration_to_seconds(duration)
     end
 
-
     private
-
 
     def key_paths
       super.merge(CALENDAR_ITEM_KEY_PATHS)
@@ -124,7 +117,6 @@ module Viewpoint::EWS::Types
     def key_alias
       super.merge(CALENDAR_ITEM_KEY_ALIAS)
     end
-
 
   end
 end

--- a/spec/unit/soap/builders/ews_builder_spec.rb
+++ b/spec/unit/soap/builders/ews_builder_spec.rb
@@ -65,4 +65,82 @@ describe Viewpoint::EWS::SOAP::EwsBuilder do
     end
 
   end
+
+  describe ".camel_case_attributes" do
+    let(:result) do
+      Viewpoint::EWS::SOAP::EwsBuilder.camel_case_attributes(input)
+    end
+
+    context "flat, no special fields" do
+      let(:input) do
+        { foo: 1, bar: "two", baz: "three" }
+      end
+
+      let(:expected) do
+        { "Foo" => 1, "Bar" => "two", "Baz" => "three" }
+      end
+
+      it "produces the expected output" do
+        expect(result).to eq(expected)
+      end
+    end
+
+    context "nested, no special fields" do
+      let(:input) do
+        { foo: 1, bar: "two", baz: { quux: "three" } }
+      end
+
+      let(:expected) do
+        { "Foo" => 1, "Bar" => "two", "Baz" => { "Quux" => "three" } }
+      end
+
+      it "produces the expected output" do
+        expect(result).to eq(expected)
+      end
+    end
+
+    context "special fields" do
+      context "text" do
+        let(:input) do
+          { foo: 1, text: "two" }
+        end
+
+        let(:expected) do
+          { "Foo" => 1, :text => "two" }
+        end
+
+        it "produces the expected output" do
+          expect(result).to eq(expected)
+        end
+      end
+
+      context "sub_elements" do
+        let(:input) do
+          { foo: 1, sub_elements: [ { bar: 2 }, { baz: "three" } ] }
+        end
+
+        let(:expected) do
+          { "Foo" => 1, :sub_elements => [ { "Bar" => 2 }, { "Baz" => "three" } ] }
+        end
+
+        it "produces the expected output" do
+          expect(result).to eq(expected)
+        end
+      end
+
+      context "xmlns_attribute" do
+        let(:input) do
+          { foo: 1, xmlns_attribute: "http://example.com/ns" }
+        end
+
+        let(:expected) do
+          { "Foo" => 1, xmlns_attribute: "http://example.com/ns" }
+        end
+
+        it "produces the expected output" do
+          expect(result).to eq(expected)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
`CalendarItem#update_item!` did not support the full range of options available via the `EwsBuilder#build_xml!` method as `:text` was the only reserved attribute preserved and a nested structure was not supported at all.

This commit makes `:sub_elements` and `:xmlns_attribute` reserved too and ensures that any nested structures are also escaped as necessary.