### PR TITLE
Replace XML version of SOAP response from 1.0 to 1.1

### DIFF
--- a/lib/ews/soap/parsers/ews_parser.rb
+++ b/lib/ews/soap/parsers/ews_parser.rb
@@ -28,6 +28,7 @@ module Viewpoint::EWS::SOAP
 
     def parse(opts = {})
       opts[:response_class] ||= EwsSoapResponse
+      @soap_resp.gsub!('version="1.0"', 'version="1.1"')
       sax_parser.parse(@soap_resp)
       opts[:response_class].new @sax_doc.struct
     end


### PR DESCRIPTION
Exchange sends SOAP response with XML version 1.0 but some SOAP responses contain characters which are valid only in XML 1.1 version. For example I see `&#x1F;` in body attribute. These invalid characters cause SAX parser to fail parsing the document.

Fixed by replacing XML version 1.0 with 1.1

Fixes:
#219 
#225 
#166 
#116