### PR TITLE
Extended props

### DIFF
--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -242,6 +242,16 @@ module Viewpoint
         end
       end
 
+      # Find Items with a specific tag
+      def find_items_with_tag(tag)
+        restrict = { :restriction => { 
+          :is_equal_to => [ {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}},
+            :field_uRI_or_constant => {:constant => {:value=>tag}} ]
+        } }
+
+        find_items(restrict)
+      end
+
       # Fetch only items from today (since midnight)
       def todays_items(opts = {})
         #opts = {:query_string => ["Received:today"]}

--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -253,14 +253,14 @@ module Viewpoint
 
       # Find Items with a specific tag
       def find_items_with_tag(tag, opts = {})
-        tagspace = opts.delete(:tagspace) || 'viewpoint_tags'
+        tagspace = opts[:tagspace] || 'viewpoint_tags'
 
         restrict = { :restriction => {
           :is_equal_to => [ {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>tagspace, :property_type=>"StringArray"}},
             {:field_uRI_or_constant => {:constant => {:value=>tag}}} ]
         } }
 
-        find_items(restrict)
+        find_items(opts.merge(restrict))
       end
 
       # Fetch only items from today (since midnight)

--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -69,7 +69,7 @@ module Viewpoint
         if( folder_type.nil? )
           resp = (Viewpoint::EWS::EWS.instance).ews.find_folder( [normalize_id(root)], traversal, {:base_shape => shape} )
         else
-          restr = {:restriction => 
+          restr = {:restriction =>
             {:is_equal_to => [{:field_uRI => {:field_uRI=>'folder:FolderClass'}}, {:field_uRI_or_constant=>{:constant => {:value => folder_type}}}]}
           }
           resp = (Viewpoint::EWS::EWS.instance).ews.find_folder( [normalize_id(root)], traversal, {:base_shape => shape}, restr)
@@ -109,7 +109,7 @@ module Viewpoint
         # For now the :field_uRI and :field_uRI_or_constant must be in an Array for Ruby 1.8.7 because Hashes
         # are not positional at insertion until 1.9
         restr = {:restriction =>
-          {:is_equal_to => 
+          {:is_equal_to =>
             [{:field_uRI => {:field_uRI=>'folder:DisplayName'}}, {:field_uRI_or_constant =>{:constant => {:value=>name}}}]}}
         resp = (Viewpoint::EWS::EWS.instance).ews.find_folder([:msgfolderroot], 'Deep', {:base_shape => shape}, restr)
         if(resp.status == 'Success')
@@ -255,7 +255,7 @@ module Viewpoint
       def find_items_with_tag(tag, opts = {})
         tagspace = opts.delete(:tagspace) || 'viewpoint_tags'
 
-        restrict = { :restriction => { 
+        restrict = { :restriction => {
           :is_equal_to => [ {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>tagspace, :property_type=>"StringArray"}},
             :field_uRI_or_constant => {:constant => {:value=>tag}} ]
         } }
@@ -274,7 +274,7 @@ module Viewpoint
       # @param [DateTime] date_time the time to fetch Items since.
       def items_since(date_time, opts = {})
         restr = {:restriction =>
-          {:is_greater_than_or_equal_to => 
+          {:is_greater_than_or_equal_to =>
             [{:field_uRI => {:field_uRI=>'item:DateTimeReceived'}},
             {:field_uRI_or_constant =>{:constant => {:value=>date_time}}}]
           }}
@@ -286,7 +286,7 @@ module Viewpoint
       # @param [DateTime] end_date the time to stop fetching Items from
       def items_between(start_date, end_date, opts={})
         restr = {:restriction =>  {:and => [
-          {:is_greater_than_or_equal_to => 
+          {:is_greater_than_or_equal_to =>
             [{:field_uRI => {:field_uRI=>'item:DateTimeReceived'}},
             {:field_uRI_or_constant=>{:constant => {:value =>start_date}}}]},
           {:is_less_than_or_equal_to =>

--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -257,7 +257,7 @@ module Viewpoint
 
         restrict = { :restriction => {
           :is_equal_to => [ {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>tagspace, :property_type=>"StringArray"}},
-            :field_uRI_or_constant => {:constant => {:value=>tag}} ]
+            {:field_uRI_or_constant => {:constant => {:value=>tag}}} ]
         } }
 
         find_items(restrict)

--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -216,8 +216,8 @@ module Viewpoint
       # Find Items
       def find_items(opts = {})
         opts = opts.clone # clone the passed in object so we don't modify it in case it's being used in a loop
-        namespace = opts.delete(:namespace) || 'viewpoint_tags'
         item_shape = opts.has_key?(:item_shape) ? opts.delete(:item_shape) : {:base_shape => 'Default'}
+        tagspace = opts.delete(:tagspace) || 'viewpoint_tags'
         if item_shape.has_key?(:additional_properties)
           aprops = item_shape[:additional_properties]
           if aprops.has_key?(:field_uRI)
@@ -228,14 +228,14 @@ module Viewpoint
           end
           if aprops.has_key?(:extended_field_uRI)
             raise EwsBadArgumentError, ":extended_field_uRI val should be an Array instead of #{aprops[:extended_field_uRI].class.name}" unless aprops[:extended_field_uRI].is_a?(Array)
-            aprops[:extended_field_uRI] << [{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}]
+            aprops[:extended_field_uRI] << [{:distinguished_property_set_id=>"PublicStrings", :property_name=>tagspace, :property_type=>"StringArray"}]
           else
-            aprops[:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}]
+            aprops[:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>tagspace, :property_type=>"StringArray"}]
           end
         else
           item_shape[:additional_properties] = {}
           item_shape[:additional_properties][:field_uRI] = ['item:ParentFolderId']
-          item_shape[:additional_properties][:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}]
+          item_shape[:additional_properties][:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>tagspace, :property_type=>"StringArray"}]
         end
         resp = (Viewpoint::EWS::EWS.instance).ews.find_item([@folder_id], 'Shallow', item_shape, opts)
         if(resp.status == 'Success')
@@ -252,11 +252,11 @@ module Viewpoint
       end
 
       # Find Items with a specific tag
-      def find_items_with_tag(tag, opts)
-        namespace = opts.delete(:namespace) || 'viewpoint_tags'
+      def find_items_with_tag(tag, opts = {})
+        tagspace = opts.delete(:tagspace) || 'viewpoint_tags'
 
         restrict = { :restriction => { 
-          :is_equal_to => [ {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}},
+          :is_equal_to => [ {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>tagspace, :property_type=>"StringArray"}},
             :field_uRI_or_constant => {:constant => {:value=>tag}} ]
         } }
 

--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -225,8 +225,16 @@ module Viewpoint
           else
             aprops[:field_uRI] = ['item:ParentFolderId']
           end
+          if aprops.has_key?(:extended_field_uRI)
+            raise EwsBadArgumentError, ":extended_field_uRI val should be an Array instead of #{aprops[:extended_field_uRI].class.name}" unless aprops[:extended_field_uRI].is_a?(Array)
+            aprops[:extended_field_uRI] << [{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}]
+          else
+            aprops[:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}]
+          end
         else
-          item_shape[:additional_properties] = {:field_uRI => ['item:ParentFolderId']}
+          item_shape[:additional_properties] = {}
+          item_shape[:additional_properties][:field_uRI] = ['item:ParentFolderId']
+          item_shape[:additional_properties][:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}]
         end
         resp = (Viewpoint::EWS::EWS.instance).ews.find_item([@folder_id], 'Shallow', item_shape, opts)
         if(resp.status == 'Success')

--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -127,12 +127,12 @@ module Viewpoint
 
       def initialize(ews_item)
         super() # Calls initialize in Model (creates @ews_methods Array)
-        @ews_item = ews_item
-        @folder_id = ews_item[:folder_id][:id]
-        @ews_methods << :folder_id
-        @ews_methods << :id
-        @change_key = ews_item[:folder_id][:change_key]
-        @ews_methods << :change_key
+        @ews_item     = ews_item
+        @folder_id    = ews_item[:folder_id][:id]
+        @ews_methods  << :folder_id
+        @ews_methods  << :id
+        @change_key   = ews_item[:folder_id][:change_key]
+        @ews_methods  << :change_key
         unless ews_item[:parent_folder_id].nil?
           @parent_id = ews_item[:parent_folder_id]
           @ews_methods << :parent_id
@@ -142,11 +142,12 @@ module Viewpoint
         # @todo Handle:
         #   <EffectiveRights/>, <ExtendedProperty/>, <ManagedFolderInformation/>, <PermissionSet/>
 
-        @sync_state = nil # Base-64 encoded sync data
-        @synced = false   # Whether or not the synchronization process is complete
-        @subscription_id = nil
-        @watermark = nil
-        @shallow = true
+        @tagspace         = (Viewpoint::EWS::EWS.instance).tagspace
+        @sync_state       = nil # Base-64 encoded sync data
+        @synced           = false   # Whether or not the synchronization process is complete
+        @subscription_id  = nil
+        @watermark        = nil
+        @shallow          = true
       end
 
       # Subscribe this folder to events.  This method initiates an Exchange pull
@@ -217,7 +218,7 @@ module Viewpoint
       def find_items(opts = {})
         opts = opts.clone # clone the passed in object so we don't modify it in case it's being used in a loop
         item_shape = opts.has_key?(:item_shape) ? opts.delete(:item_shape) : {:base_shape => 'Default'}
-        tagspace = opts.delete(:tagspace) || 'viewpoint_tags'
+        tagspace = opts.delete(:tagspace) || @tagspace
         if item_shape.has_key?(:additional_properties)
           aprops = item_shape[:additional_properties]
           if aprops.has_key?(:field_uRI)
@@ -253,7 +254,7 @@ module Viewpoint
 
       # Find Items with a specific tag
       def find_items_with_tag(tag, opts = {})
-        tagspace = opts[:tagspace] || 'viewpoint_tags'
+        tagspace = opts[:tagspace] || @tagspace
 
         restrict = { :restriction => {
           :is_equal_to => [ {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>tagspace, :property_type=>"StringArray"}},

--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -217,7 +217,17 @@ module Viewpoint
       def find_items(opts = {})
         opts = opts.clone # clone the passed in object so we don't modify it in case it's being used in a loop
         item_shape = opts.has_key?(:item_shape) ? opts.delete(:item_shape) : {:base_shape => 'Default'}
-        item_shape[:additional_properties] = {:field_uRI => ['item:ParentFolderId']}
+        if item_shape.has_key?(:additional_properties)
+          aprops = item_shape[:additional_properties]
+          if aprops.has_key?(:field_uRI)
+            raise EwsBadArgumentError, ":field_uRI val should be an Array instead of #{aprops[:field_uRI].class.name}" unless aprops[:field_uRI].is_a?(Array)
+            aprops[:field_uRI] << ['item:ParentFolderId']
+          else
+            aprops[:field_uRI] = ['item:ParentFolderId']
+          end
+        else
+          item_shape[:additional_properties] = {:field_uRI => ['item:ParentFolderId']}
+        end
         resp = (Viewpoint::EWS::EWS.instance).ews.find_item([@folder_id], 'Shallow', item_shape, opts)
         if(resp.status == 'Success')
           parms = resp.items.shift

--- a/lib/model/generic_folder.rb
+++ b/lib/model/generic_folder.rb
@@ -216,6 +216,7 @@ module Viewpoint
       # Find Items
       def find_items(opts = {})
         opts = opts.clone # clone the passed in object so we don't modify it in case it's being used in a loop
+        namespace = opts.delete(:namespace) || 'viewpoint_tags'
         item_shape = opts.has_key?(:item_shape) ? opts.delete(:item_shape) : {:base_shape => 'Default'}
         if item_shape.has_key?(:additional_properties)
           aprops = item_shape[:additional_properties]
@@ -227,14 +228,14 @@ module Viewpoint
           end
           if aprops.has_key?(:extended_field_uRI)
             raise EwsBadArgumentError, ":extended_field_uRI val should be an Array instead of #{aprops[:extended_field_uRI].class.name}" unless aprops[:extended_field_uRI].is_a?(Array)
-            aprops[:extended_field_uRI] << [{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}]
+            aprops[:extended_field_uRI] << [{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}]
           else
-            aprops[:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}]
+            aprops[:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}]
           end
         else
           item_shape[:additional_properties] = {}
           item_shape[:additional_properties][:field_uRI] = ['item:ParentFolderId']
-          item_shape[:additional_properties][:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}]
+          item_shape[:additional_properties][:extended_field_uRI] = [{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}]
         end
         resp = (Viewpoint::EWS::EWS.instance).ews.find_item([@folder_id], 'Shallow', item_shape, opts)
         if(resp.status == 'Success')
@@ -251,9 +252,11 @@ module Viewpoint
       end
 
       # Find Items with a specific tag
-      def find_items_with_tag(tag)
+      def find_items_with_tag(tag, opts)
+        namespace = opts.delete(:namespace) || 'viewpoint_tags'
+
         restrict = { :restriction => { 
-          :is_equal_to => [ {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}},
+          :is_equal_to => [ {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}},
             :field_uRI_or_constant => {:constant => {:value=>tag}} ]
         } }
 

--- a/lib/model/item.rb
+++ b/lib/model/item.rb
@@ -296,10 +296,11 @@ module Viewpoint
         end
       end
 
-      def clear_all_tags!
+      def clear_all_tags!(options)
+        namespace = options[:namespace] || 'viewpoint_tags'
         vtag = {:preformatted => []}
         vtag[:preformatted] << {:delete_item_field => 
-          {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}}
+          {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}}
         }
 
         if(self.update_attribs!(vtag))
@@ -311,7 +312,8 @@ module Viewpoint
       end
 
       # @param [Array<String>] tags viewpoint_tags to set on this item
-      def set_tags!(tags)
+      def set_tags!(tags, options)
+        namespace = options[:namespace] || 'viewpoint_tags'
         i_type = self.class.name.split(/::/).last.ruby_case.to_sym
 
         tag_vals = []
@@ -321,10 +323,10 @@ module Viewpoint
 
         vtag = {:preformatted => []}
         vtag[:preformatted] << {:set_item_field => [
-          {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}},
+          {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}},
           {i_type => [
             {:extended_property => [
-              {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}},
+              {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>namespace, :property_type=>"StringArray"}},
               {:values => tag_vals}
             ]}
           ]}
@@ -363,11 +365,13 @@ module Viewpoint
         end
       end
 
-      def parse_tags
+      def parse_tags(options)
+        namespace = options[:namespace] || 'viewpoint_tags'
+
         return [] unless(@ews_item.has_key?(:extended_property) &&
                          @ews_item[:extended_property].has_key?(:extended_field_u_r_i) &&
                          @ews_item[:extended_property][:extended_field_u_r_i].has_key?(:property_name) &&
-                         @ews_item[:extended_property][:extended_field_u_r_i][:property_name] == 'viewpoint_tags')
+                         @ews_item[:extended_property][:extended_field_u_r_i][:property_name] == namespace)
 
         tags = []
         vals = @ews_item[:extended_property][:values][:value]

--- a/lib/model/item.rb
+++ b/lib/model/item.rb
@@ -70,13 +70,14 @@ module Viewpoint
       # @param [Boolean] shallow Whether or not we have retrieved all the elements for this object
       def initialize(ews_item, shallow = true)
         super() # Calls initialize in Model (creates @ews_methods Array)
-        @ews_item = ews_item
-        @shallow = shallow
-        @item_id = ews_item[:item_id][:id]
+        @ews_item   = ews_item
+        @shallow    = shallow
+        @item_id    = ews_item[:item_id][:id]
         @change_key = ews_item[:item_id][:change_key]
-        @text_only = false
-        @updates = {}
-        @tags = parse_tags
+        @text_only  = false
+        @updates    = {}
+        @tags       = parse_tags
+        @tagspace   = (Viewpoint::EWS::EWS.instance).tagspace
 
         init_methods
       end
@@ -303,7 +304,7 @@ module Viewpoint
       # @param [Hash] opts options to pass to clear_all_tags!
       # @option opts [String] :tagspace the namespace to add the tag to. (default: 'viewpoint_tags')
       def clear_all_tags!(opts={})
-        tagspace = opts[:tagspace] || 'viewpoint_tags'
+        tagspace = opts[:tagspace] || @tagspace
         vtag = {:preformatted => []}
         vtag[:preformatted] << {:delete_item_field =>
           {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>tagspace, :property_type=>"StringArray"}}
@@ -321,7 +322,7 @@ module Viewpoint
       # @param [Hash] opts options to pass to set_tags!
       # @option opts [String] :tagspace the namespace to add the tag to. (default: 'viewpoint_tags')
       def set_tags!(tags, opts={})
-        tagspace = opts[:tagspace] || 'viewpoint_tags'
+        tagspace = opts[:tagspace] || @tagspace
         i_type = self.class.name.split(/::/).last.ruby_case.to_sym
 
         tag_vals = []
@@ -374,7 +375,7 @@ module Viewpoint
       end
 
       def parse_tags(opts={})
-        tagspace = opts[:tagspace] || 'viewpoint_tags'
+        tagspace = opts[:tagspace] || @tagspace
 
         return [] unless(@ews_item.has_key?(:extended_property) &&
                          @ews_item[:extended_property].has_key?(:extended_field_u_r_i) &&

--- a/lib/model/item.rb
+++ b/lib/model/item.rb
@@ -282,11 +282,35 @@ module Viewpoint
       # Use ExtendedProperties to create tags
       # @param [String] tag a tag to add to this item
       def add_tag!(tag)
+        @tags |= [tag]
+        set_tags!(@tags)
+      end
+
+      # @param [String] tag a tag to delete from this item
+      def remove_tag!(tag)
+        @tags -= [tag]
+        if(@tags.blank?)
+          clear_all_tags!
+        else
+          set_tags!(@tags)
+        end
+      end
+
+      def clear_all_tags!
+        vtag = {:preformatted => []}
+        vtag[:preformatted] << {:delete_item_field => 
+          {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}}
+        }
+
+        self.update_attribs!(vtag)
+      end
+
+      # @param [Array<String>] tags viewpoint_tags to set on this item
+      def set_tags!(tags)
         i_type = self.class.name.split(/::/).last.ruby_case.to_sym
 
-        @tags |= [tag]
         tag_vals = []
-        @tags.each do |t|
+        tags.each do |t|
           tag_vals << {:value => {:text => t}}
         end
 
@@ -303,7 +327,6 @@ module Viewpoint
 
         self.update_attribs!(vtag)
       end
-
 
       private
 

--- a/lib/model/item.rb
+++ b/lib/model/item.rb
@@ -278,6 +278,24 @@ module Viewpoint
         GenericFolder.get_folder @parent_folder_id
       end
 
+      # Use ExtendedProperties to create tags
+      # @param [String] tag a tag to add to this item
+      def add_tag!(tag)
+        i_type = self.class.name.split(/::/).last.ruby_case.to_sym
+
+        vtag = {:preformatted => []}
+        vtag[:preformatted] << {:set_item_field => [
+          {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}},
+          {i_type => [
+            {:extended_property => [
+              {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}},
+              {:values => [ {:value => {:text => tag} }]}
+            ]}
+          ]}
+        ]}
+
+        self.update_attribs!(vtag)
+      end
 
 
       private

--- a/lib/model/item.rb
+++ b/lib/model/item.rb
@@ -282,13 +282,13 @@ module Viewpoint
       # Use ExtendedProperties to create tags
       # @param [String] tag a tag to add to this item
       def add_tag!(tag)
-        @tags |= [tag]
+        @tags |= [tag.downcase]
         set_tags!(@tags)
       end
 
       # @param [String] tag a tag to delete from this item
       def remove_tag!(tag)
-        @tags -= [tag]
+        @tags -= [tag.downcase]
         if(@tags.blank?)
           clear_all_tags!
         else
@@ -302,7 +302,12 @@ module Viewpoint
           {:extended_field_uRI=>{:distinguished_property_set_id=>"PublicStrings", :property_name=>"viewpoint_tags", :property_type=>"StringArray"}}
         }
 
-        self.update_attribs!(vtag)
+        if(self.update_attribs!(vtag))
+          @tags = []
+          true
+        else
+          false
+        end
       end
 
       # @param [Array<String>] tags viewpoint_tags to set on this item

--- a/lib/model/item.rb
+++ b/lib/model/item.rb
@@ -294,7 +294,7 @@ module Viewpoint
       def remove_tag!(tag, opts={})
         @tags -= [tag.downcase]
         if(@tags.blank?)
-          clear_all_tags!
+          clear_all_tags!(opts)
         else
           set_tags!(@tags, opts)
         end

--- a/lib/viewpoint.rb
+++ b/lib/viewpoint.rb
@@ -81,7 +81,7 @@ module Viewpoint
       include Singleton
       include Viewpoint
 
-      attr_reader :ews
+      attr_reader :ews, :tagspace
 
       # Set the endpoint for Exchange Web Services.  
       # @param [String] endpoint The URL of the endpoint. This should end in
@@ -122,12 +122,20 @@ module Viewpoint
       end
 
       def initialize
+        @tagspace ||= 'viewpoint_tags'
         @ews = SOAP::ExchangeWebService.new
       end
 
       # The MailboxUser object that represents the user connected to EWS.
       def me
         MailboxUser.find_user((@@user.include?('@') ? @@user : "#{@@user}@"))
+      end
+
+      # Set the tagspace used for creating tags on the Model objects. Under the covers this uses
+      # a StringArray and Exchange extended properties.
+      # @param [String] tagspace the name of the tagspace to collect tags in (default: viewpoint_tags)
+      def set_tagspace(tagspace)
+        @tagspace = tagspace.to_s
       end
 
     end # class EWS

--- a/lib/viewpoint.rb
+++ b/lib/viewpoint.rb
@@ -77,11 +77,15 @@ module Viewpoint
     # @attr_reader [Viewpoint::EWS::SOAP::ExchangeWebService] :ews The EWS object used
     #   to make SOAP calls.  You typically don't need to use this, but if you want to
     #   play around with the SOAP back-end it's available.
+    # @attr_accessor [String] :tagspace the name of the tagspace to collect tags in (default: viewpoint_tags)
+    #   Set the tagspace used for creating tags on the Model objects. Under the covers this uses an Exchange
+    #   StringArray and Exchange extended properties.
     class EWS
       include Singleton
       include Viewpoint
 
-      attr_reader :ews, :tagspace
+      attr_reader :ews
+      attr_accessor :tagspace
 
       # Set the endpoint for Exchange Web Services.  
       # @param [String] endpoint The URL of the endpoint. This should end in
@@ -129,13 +133,6 @@ module Viewpoint
       # The MailboxUser object that represents the user connected to EWS.
       def me
         MailboxUser.find_user((@@user.include?('@') ? @@user : "#{@@user}@"))
-      end
-
-      # Set the tagspace used for creating tags on the Model objects. Under the covers this uses
-      # a StringArray and Exchange extended properties.
-      # @param [String] tagspace the name of the tagspace to collect tags in (default: viewpoint_tags)
-      def set_tagspace(tagspace)
-        @tagspace = tagspace.to_s
       end
 
     end # class EWS


### PR DESCRIPTION
I find an attribut on item type object not implemented which is "data_time_received" that I would like to have without using get_all_properties.
Is it possible to change item.rb file for adding in ITEM_KEY_PATHS = date_time_received : [:date_time_sent, :text],
and 
ITEM_KEY_TYPES = date_time_received:  ->(str){DateTime.parse(str)},

Thanks,