### PR TITLE
Support connect timeout option

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -28,6 +28,8 @@ class Viewpoint::EWS::Connection
   # @option opts [Fixnum] :ssl_verify_mode
   # @option opts [Fixnum] :receive_timeout override the default receive timeout
   #   seconds
+  # @option opts [Fixnum] :connect_timeout override the default connect timeout
+  #   seconds
   # @option opts [Array]  :trust_ca an array of hashed dir paths or a file
   def initialize(endpoint, opts = {})
     @log = Logging.logger[self.class.name.to_s.to_sym]

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -43,6 +43,7 @@ class Viewpoint::EWS::Connection
     # Up the keep-alive so we don't have to do the NTLM dance as often.
     @httpcli.keep_alive_timeout = 60
     @httpcli.receive_timeout = opts[:receive_timeout] if opts[:receive_timeout]
+    @httpcli.connect_timeout = opts[:connect_timeout] if opts[:connect_timeout]
     @endpoint = endpoint
   end
 


### PR DESCRIPTION
This PR adds the ability for client to override default for connect_timeout by sending something like this:

`ews = Viewpoint::EWSClient.new @endpoint, @email, @pass, http_opts: { connect_timeout: 90 }`

Currently, the only timeout one can override is the receive_timeout.
