### PR TITLE
Add method to find items via the calendar view

### DIFF
--- a/lib/ews/types/calendar_folder.rb
+++ b/lib/ews/types/calendar_folder.rb
@@ -28,6 +28,19 @@ module Viewpoint::EWS::Types
       end
     end
 
+    # Fetch items between a given time period using a calendar view.
+    # The calendar view will include occurences of recurring calendar items
+    # next to the regular single calendar items.
+    # @param [DateTime] start_date the time to start fetching Items from
+    # @param [DateTime] end_date the time to stop fetching Items from
+    # @param opts [Hash]
+    # @option opts :max_entries_returned [Integer] the maximum number of entries to return
+    def items_between_calendar_view(start_date, end_date, opts={})
+      view_opts = {:start_date => start_date, :end_date => end_date}
+      view_opts[:max_entries_returned] = opts.delete(:max_entries_returned) if opts[:max_entries_returned]
+      items(opts.merge(:calendar_view => view_opts))
+    end
+
     # Creates a new appointment
     # @param attributes [Hash] Parameters of the calendar item. Some example attributes are listed below.
     # @option attributes :subject [String]


### PR DESCRIPTION
Add a method that can use the calendar view.  This brings back the functionality already present in Viewpoint 0.1.27 (and earlier).  This addresses issue #270.