### PR TITLE
allow providing a custom certificate store

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -30,6 +30,7 @@ class Viewpoint::EWS::Connection
   #   seconds
   # @option opts [Fixnum] :connect_timeout override the default connect timeout
   #   seconds
+  # @option opts [OpenSSL::X509::Store]  :cert_store a custom cert store
   # @option opts [Array]  :trust_ca an array of hashed dir paths or a file
   # @option opts [String] :user_agent the http user agent to use in all requests
   def initialize(endpoint, opts = {})

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -40,7 +40,13 @@ class Viewpoint::EWS::Connection
       @httpcli = HTTPClient.new
     end
 
-    if opts[:trust_ca]
+    if opts[:cert_store].is_a?(OpenSSL::X509::Store)
+      @log.debug 'Applying custom cert_store provided via opts[:cert_store]'
+      # Assign the provided store directly
+      @httpcli.ssl_config.cert_store = opts[:cert_store]
+
+      @log.debug 'Skipping original :trust_ca handling due to provided :cert_store.'
+    elsif opts[:trust_ca]
       @httpcli.ssl_config.clear_cert_store
       opts[:trust_ca].each do |ca|
         @httpcli.ssl_config.add_trust_ca ca


### PR DESCRIPTION
I recently has an issue with a customer having a valid certificate chain, but nevertheless the viewpoint gem raised error `certificate verify failed (unable to get local issuer certificate) (OpenSSL::SSL::SSLError)` when trying to access their server. Their certificate was generated with Let's Encrypt.

I fixed this error by providing the default certificate store for use by EWSClient, like this
```ruby
cert_store = OpenSSL::X509::Store.new
cert_store.set_default_paths
Viewpoint::EWSClient.new(url, username, password, http_opts: { cert_store: })
```

I'm not sure why Viewpoint doesn't use the system certificate store by default, and there may be a more elegant fix to this, but I thought I would put this out there.