### PR TITLE
Add support for setting default headers on http-opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ end
 If you see something that could be done better or would like
 to help out in the development of this code please feel free to clone the
 'git' repository and send me patches:
-`git clone git://github.com/zenchild/Viewpoint.git`
+`git clone https://github.com/WinRb/Viewpoint.git`
 or add an issue on GitHub:
-http://github.com/zenchild/Viewpoint/issues
+https://github.com/WinRb/Viewpoint/issues
 
 Cheers!

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -22,6 +22,8 @@ class Viewpoint::EWS::Connection
   include Viewpoint::EWS
 
   attr_reader :endpoint
+  @@supported_httpclient_opts = %i[agent_name default_header]
+
   # @param [String] endpoint the URL of the web service.
   #   @example https://<site>/ews/Exchange.asmx
   # @param [Hash] opts Misc config options (mostly for development)
@@ -34,13 +36,9 @@ class Viewpoint::EWS::Connection
   # @option opts [String] :user_agent the http user agent to use in all requests
   def initialize(endpoint, opts = {})
     @log = Logging.logger[self.class.name.to_s.to_sym]
-     if opts[:default_header]
-      @httpcli = HTTPClient.new(default_header: opts[:default_header])
-    elsif opts[:user_agent]
-      @httpcli = HTTPClient.new(agent_name: opts[:user_agent])
-    else
-      @httpcli = HTTPClient.new
-    end
+
+    httpclient_opts = opts.slice(*@@supported_httpclient_opts)
+    @httpcli = HTTPClient.new(**httpclient_opts)
 
     if opts[:trust_ca]
       @httpcli.ssl_config.clear_cert_store

--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -24,7 +24,7 @@ class Viewpoint::EWS::Connection
   attr_reader :endpoint
   # @param [String] endpoint the URL of the web service.
   #   @example https://<site>/ews/Exchange.asmx
-  # @param [Hash] opts Misc config options (mostly for developement)
+  # @param [Hash] opts Misc config options (mostly for development)
   # @option opts [Fixnum] :ssl_verify_mode
   # @option opts [Fixnum] :receive_timeout override the default receive timeout
   #   seconds
@@ -34,7 +34,9 @@ class Viewpoint::EWS::Connection
   # @option opts [String] :user_agent the http user agent to use in all requests
   def initialize(endpoint, opts = {})
     @log = Logging.logger[self.class.name.to_s.to_sym]
-    if opts[:user_agent]
+     if opts[:default_header]
+      @httpcli = HTTPClient.new(default_header: opts[:default_header])
+    elsif opts[:user_agent]
       @httpcli = HTTPClient.new(agent_name: opts[:user_agent])
     else
       @httpcli = HTTPClient.new


### PR DESCRIPTION
Allow for setting default headers beyond agent_name adding customization

Note: Looks like changelog.txt is not is use, but happy to update. 